### PR TITLE
hard code 'cache=FALSE' in the appendix chunk

### DIFF
--- a/R/multi_report.R
+++ b/R/multi_report.R
@@ -26,7 +26,8 @@ panel_types <- c("source" = "panel-primary",
 #' @export
 multi_document <- function(theme = NULL, highlight = NULL, pandoc_args = NULL,
                            fig_format=c('screen', 'print'), fig_download=TRUE,
-                           use_namespace=FALSE, ...){
+                           use_namespace=FALSE, template = system.file(
+                             package="reportMD", "rmarkdown/rmd/default.html"), ...){
   theme <- theme %||% "default"
   highlight <- highlight %||% "default"
   pandoc_args <- pandoc_args %||% c(
@@ -44,9 +45,6 @@ multi_document <- function(theme = NULL, highlight = NULL, pandoc_args = NULL,
       html_dependency_navigation(),
       html_dependency_multi()
     ),
-    template =
-      system.file(
-        package="reportMD", "rmarkdown/rmd/default.html"),
     pandoc_args = check_pandoc_args(pandoc_args), ...)
   ff <- character()
   for(format in fig_format){
@@ -82,6 +80,11 @@ multi_document <- function(theme = NULL, highlight = NULL, pandoc_args = NULL,
     knit_hooks = multi_knit_hooks(),
     opts_hooks = multi_opts_hooks()
   )
+
+  # first call to 'rmarkdown::html_document' uses the default template to retain MathJax functionality
+  # then the pandoc template setting is modified to use the custom template
+  template_arg <- which(results$pandoc$args == "--template") + 1L
+  results$pandoc$args[template_arg] <- template
 
   results
 }

--- a/inst/rmarkdown/templates/multipart_report/skeleton/part1.Rmd
+++ b/inst/rmarkdown/templates/multipart_report/skeleton/part1.Rmd
@@ -62,5 +62,5 @@ ext_cars$origin[international] <- 'international'
 ```
 
 
-```{r appendix, child='rmd/appendix.Rmd'}
+```{r appendix, child='rmd/appendix.Rmd', cache=FALSE}
 ```

--- a/inst/rmarkdown/templates/multipart_report/skeleton/part2.Rmd
+++ b/inst/rmarkdown/templates/multipart_report/skeleton/part2.Rmd
@@ -83,6 +83,13 @@ reg_fig <- ggplot(ext_cars, aes(x=wt, y=mpg, colour=origin, text=rownames(ext_ca
   theme_bw()
 ```
 
+Just to let you know - MathJax does work with this custom template so you can insert any LaTeX expression you want.  
+Here we just use a random formula to demonstrate that everything is working. Check [this link](http://www.calvin.edu/~rpruim/courses/m343/F12/RStudio/LatexExamples.html) for a briew overview of basic LaTeX commands.
+
+$$
+nri_{B1,B2}=\frac{R_{B1}-R_{B2}}{R_{B1}+R_{B2}}
+$$
+
 ```{r appendix, child='rmd/appendix.Rmd', cache=FALSE}
 ```
 

--- a/inst/rmarkdown/templates/multipart_report/skeleton/part2.Rmd
+++ b/inst/rmarkdown/templates/multipart_report/skeleton/part2.Rmd
@@ -83,6 +83,6 @@ reg_fig <- ggplot(ext_cars, aes(x=wt, y=mpg, colour=origin, text=rownames(ext_ca
   theme_bw()
 ```
 
-```{r appendix, child='rmd/appendix.Rmd'}
+```{r appendix, child='rmd/appendix.Rmd', cache=FALSE}
 ```
 

--- a/inst/rmarkdown/templates/multipart_report/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/multipart_report/skeleton/skeleton.Rmd
@@ -171,6 +171,6 @@ Links to all document dependencies listed in the header will be added to the *Re
 It is also possible to link to a figure or table in a child document by providing the corresponding label
 from the list of dependencies to indicate the target file: `r figRef('boxplot', target='part2')`.
 
-```{r appendix, child='rmd/appendix.Rmd'}
+```{r appendix, child='rmd/appendix.Rmd', cache=FALSE}
 ```
 


### PR DESCRIPTION
Otherwise, the appendix never gets updated when one has set the global option `knitr::opts_chunk$set(cache = TRUE)`. This is especially problematic for the 'version' part of the appendix.