### PR TITLE
Feature/targetted links

### DIFF
--- a/R/generics.R
+++ b/R/generics.R
@@ -47,24 +47,30 @@ printMD.integer <- function(x, big.mark=',', ...){
 }
 
 #' @param format Format type to use.
+#' @param target Specify an anchor in the output document for \code{x} that the
+#' link should point to.
 #' @method printMD Dependency
 #' @export
 #' @rdname printMD
-printMD.Dependency <- function(x, format=c('markdown', 'html', 'reference', 'md reference'), ...){
+printMD.Dependency <- function(x, target, format=c('markdown', 'html', 'reference', 'md reference'),
+                               text=x$title, ...){
   format <- tolower(format)
   format <- match.arg(format)
   rel_path <- basename(x$document)
+  if(!missing(target)){
+    rel_path <- paste(rel_path, target, sep='#')
+  }
   if(format == 'markdown'){
-    link <- paste0('[', x$title, '](', rel_path, ')')
+    link <- paste0('[', text, '](', rel_path, ')')
   } else if(format == 'html'){
-    link <- paste0('<a href=', rel_path, '>', x$title, '</a>')
+    link <- paste0('<a href=', rel_path, '>', text, '</a>')
   } else if(format == 'reference'){
     link <- paste0('[', x$label, ']: ', rel_path)
-    if(x$title != 'Untitled'){
-      link <- paste0(link, ' (', x$title, ')')
+    if(!missing(text) || text != 'Untitled'){
+      link <- paste0(link, ' (', text, ')')
     }
   } else if(format == 'md reference'){
-    link <- paste0('[', x$title, '][', x$label, ']')
+    link <- paste0('[', text, '][', x$label, ']')
   }
   link
 }

--- a/R/generics.R
+++ b/R/generics.R
@@ -49,6 +49,7 @@ printMD.integer <- function(x, big.mark=',', ...){
 #' @param format Format type to use.
 #' @param target Specify an anchor in the output document for \code{x} that the
 #' link should point to.
+#' @param text Text that should be displayed as part of the link.
 #' @method printMD Dependency
 #' @export
 #' @rdname printMD

--- a/inst/rmarkdown/templates/multipart_report/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/multipart_report/skeleton/skeleton.Rmd
@@ -168,6 +168,19 @@ It may be useful to add links to the child documents in appropriate places throu
 be achieved using *pandoc*'s reference link syntax. For example, to link to [Part 2][part2] simply use `[some text][part2]`.
 Links to all document dependencies listed in the header will be added to the *Related Documents* section of the appendix.
 
+It is possible to link to specific parts of a child document by using the corresponding 
+dependency object directly. 
+
+```{r get_dependencies}
+deps <- knitr::opts_knit$get('dependencies')
+```
+
+Printing a dependency object (*via* `printMD`) will insert a reference to the
+corresponding output document in the text. The optional `target` argument
+to `printMD` allows to specify any anchor for the link. This can correspond
+to a heading, e.g. see the `r printMD(deps$part1, target='introduction', text='Introduction of Part1')`,
+or a code chunk (details of the `r printMD(deps$part2, target='regression', text='regression model used in Part2')`).
+
 It is also possible to link to a figure or table in a child document by providing the corresponding label
 from the list of dependencies to indicate the target file: `r figRef('boxplot', target='part2')`.
 

--- a/inst/rmarkdown/templates/multipart_report/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/multipart_report/skeleton/skeleton.Rmd
@@ -178,8 +178,8 @@ deps <- knitr::opts_knit$get('dependencies')
 Printing a dependency object (*via* `printMD`) will insert a reference to the
 corresponding output document in the text. The optional `target` argument
 to `printMD` allows to specify any anchor for the link. This can correspond
-to a heading, e.g. see the `r printMD(deps$part1, target='introduction', text='Introduction of Part1')`,
-or a code chunk (details of the `r printMD(deps$part2, target='regression', text='regression model used in Part2')`).
+to a heading, e.g. see the `r printMD(deps$part1, target='introduction', text='Introduction of Part 1')`,
+or a code chunk (details of the `r printMD(deps$part2, target='regression', text='regression model used in Part 2')`).
 
 It is also possible to link to a figure or table in a child document by providing the corresponding label
 from the list of dependencies to indicate the target file: `r figRef('boxplot', target='part2')`.

--- a/man/printMD.Rd
+++ b/man/printMD.Rd
@@ -33,6 +33,8 @@ printMD(x, ...)
 link should point to.}
 
 \item{format}{Format type to use.}
+
+\item{text}{Text that should be displayed as part of the link.}
 }
 \value{
 String representation of x formatted for printing.

--- a/man/printMD.Rd
+++ b/man/printMD.Rd
@@ -17,8 +17,8 @@ printMD(x, ...)
 
 \method{printMD}{integer}(x, big.mark = ",", ...)
 
-\method{printMD}{Dependency}(x, format = c("markdown", "html", "reference",
-  "md reference"), ...)
+\method{printMD}{Dependency}(x, target, format = c("markdown", "html",
+  "reference", "md reference"), text = x$title, ...)
 }
 \arguments{
 \item{x}{Object to be printed}
@@ -28,6 +28,9 @@ printMD(x, ...)
 \item{big.mark}{Separator used to mark intervals before the decimal point.}
 
 \item{digits}{Number of sinificant digits to display, passed to \code{format}}
+
+\item{target}{Specify an anchor in the output document for \code{x} that the
+link should point to.}
 
 \item{format}{Format type to use.}
 }


### PR DESCRIPTION
Provide facilities to generate links to child documents that point to anchors in the child, not just the top of the document.